### PR TITLE
Enable back button for both flowchart and advanced search actions

### DIFF
--- a/app/src/declaration/declaration.module.js
+++ b/app/src/declaration/declaration.module.js
@@ -63,7 +63,8 @@ function config($stateProvider) {
       url: '/sag/:caseid',
       params: {
               searchquery: {},
-              type: ''
+              type: '',
+              index: -1
             },
       views: {
         'content@': {

--- a/app/src/declaration/declaration.module.js
+++ b/app/src/declaration/declaration.module.js
@@ -62,7 +62,8 @@ function config($stateProvider) {
     .state('declaration.show', {
       url: '/sag/:caseid',
       params: {
-              searchquery: {}
+              searchquery: {},
+              type: ''
             },
       views: {
         'content@': {

--- a/app/src/declaration/patientInfo.controller.js
+++ b/app/src/declaration/patientInfo.controller.js
@@ -107,7 +107,7 @@ function PatientInfoController($scope, $state, $stateParams, $mdDialog, Declarat
 
 
 		if (vm.backtosearch) {
-            HeaderService.addAction('Tilbage til søgning', 'description', gobacktosearch, false)
+            HeaderService.addAction('Tilbage', 'description', gobacktosearch, false)
         }
 
 		HeaderService.addAction('Opret erklæring', 'description', makeDeclarationDocument, false, declarationSettings)

--- a/app/src/flowchart/data-row.html
+++ b/app/src/flowchart/data-row.html
@@ -52,15 +52,15 @@
 
                 <md-button class="md-raised" ng-disabled="vm.saveShow" ng-click="vm.editing=true;collapsed=vm.editCase(i);save=collapsed;" ng-hide="!collapsed">Ret</md-button>
 
-                <md-button class="md-raised md-primary" ng-click="save=false;vm.editing=false;;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status)" ng-show="vm.saveShow">Gem</md-button>
+                <md-button class="md-raised md-primary" ng-click="save=false;vm.editing=false;;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status, $index)" ng-show="vm.saveShow">Gem</md-button>
 
                 <md-button class="md-raised" ng-click="save=false;vm.editing=false;;vm.cancel(i.node_uuid)" ng-show="vm.saveShow">Annuller</md-button>
 
-                <md-button class="md-icon-button md-raised" ng-show="!collapsed && !vm.editing" ng-click="collapsed=!collapsed;vm.updateCard(i)">
+                <md-button class="md-icon-button md-raised show-details" ng-show="!collapsed && !vm.editing" ng-click="collapsed=!collapsed;vm.openCase($index)">
                     <md-tooltip>Vis detaljer</md-tooltip>
                     <md-icon>keyboard_arrow_down</md-icon>
                 </md-button>
-                <md-button class="md-icon-button md-raised" ng-show="collapsed && !vm.editing" ng-click="collapsed=!collapsed">
+                <md-button class="md-icon-button md-raised hide-details" ng-show="collapsed && !vm.editing" ng-click="collapsed=!collapsed">
                     <md-tooltip>Skjul detaljer</md-tooltip>
                     <md-icon>keyboard_arrow_up</md-icon>
                 </md-button>

--- a/app/src/flowchart/flowchart.controller.js
+++ b/app/src/flowchart/flowchart.controller.js
@@ -27,7 +27,7 @@ angular
       });
 
 
-function FlowChartController($scope, $stateParams, $translate, HeaderService, FlowChartService, propertyService, filterService, DeclarationService, Toast, authService, $anchorScroll, $location, $timeout, $state ) {
+function FlowChartController($scope, $translate, HeaderService, FlowChartService, propertyService, filterService, DeclarationService, Toast, authService, $anchorScroll, $location, $timeout, $state ) {
   var vm = this;
 
   $scope.flow = {};
@@ -59,9 +59,10 @@ function FlowChartController($scope, $stateParams, $translate, HeaderService, Fl
    return !(item.Message === null || item.Message.trim().length === 0)
   }
 
-
-
-
+  // on page load, get the data
+  $timeout(function() {
+    loaddata($state.params.type, '@rm:creationDate', 'true');
+  }, 0);
 
 
 function propertyFilter(array, query) {
@@ -71,7 +72,7 @@ function propertyFilter(array, query) {
 
 
     function gotoCase(caseNumber) {
-        $state.go('declaration.show', { caseid: caseNumber });
+        $state.go('declaration.show', { caseid: caseNumber, type: $state.params.type });
     }
 
     vm.gotoCase = gotoCase;
@@ -104,20 +105,20 @@ function propertyFilter(array, query) {
 
 
 
-    $timeout(function() {
-        loaddata('ongoing', '@rm:creationDate', 'true');
-        vm.currentCard = "ongoing";
-        }, 0);
   }
 
   function loaddata(value, sort, desc) {
+    $state.go('flowchart', {
+      type: value
+    }).then(function(state) {
       vm.showing = value;
       vm.currentCard = value;
 
-      FlowChartService.getEntries(value, sort, desc).then(function (response) {
-          vm.ongoing = response.entries;
-      });
- }
+      return FlowChartService.getEntries(value, sort, desc);
+    }).then(function (response) {
+      vm.ongoing = response.entries;
+    });
+  }
 
 
 
@@ -336,6 +337,3 @@ function propertyFilter(array, query) {
 
     vm.visitate = visitate;
 }
-
-
-

--- a/app/src/flowchart/flowchart.controller.js
+++ b/app/src/flowchart/flowchart.controller.js
@@ -27,7 +27,7 @@ angular
       });
 
 
-function FlowChartController($scope, $translate, HeaderService, FlowChartService, propertyService, filterService, DeclarationService, Toast, authService, $anchorScroll, $location, $timeout, $state ) {
+function FlowChartController($scope, $rootScope, $translate, HeaderService, FlowChartService, propertyService, filterService, DeclarationService, Toast, authService, $anchorScroll, $location, $timeout, $state ) {
   var vm = this;
 
   $scope.flow = {};
@@ -35,7 +35,6 @@ function FlowChartController($scope, $translate, HeaderService, FlowChartService
   $scope.folderUuid = [];
 
   HeaderService.setTitle($translate.instant('COMMON.FLOWCHART'))
-  activate();
 
   vm.updateCollapse = updateCollapse;
   vm.propertyValues = propertyService.getAllPropertyValues();
@@ -60,22 +59,47 @@ function FlowChartController($scope, $translate, HeaderService, FlowChartService
   }
 
   // on page load, get the data
-  $timeout(function() {
-    loaddata($state.params.type, '@rm:creationDate', 'true');
-  }, 0);
+  activate().then(function() {
+    return loaddata($state.params.type, '@rm:creationDate', 'true');
+  }).then(function() {
+    if ($rootScope.ongoing && $rootScope.ongoing.length && $state.params.index > -1) {
+      // simulate clicking on the "expand" button of the index'th item
+      // however, we have to wait until the UI has been rendered before
+      // the element exists on the page
+      var targetUuid = $rootScope.ongoing[$state.params.index].node_uuid;
+      var tick = setInterval(function() {
+        var targetButton = $('#' + targetUuid + ' .show-details');
+        if (targetButton.length) {
+          clearInterval(tick);
+          targetButton.trigger('click');
+        }
+      }, 100);
+    }
+  });
 
-
-function propertyFilter(array, query) {
+  function propertyFilter(array, query) {
 		return filterService.propertyFilter(array, query);
 	}
 
 
 
-    function gotoCase(caseNumber) {
-        $state.go('declaration.show', { caseid: caseNumber, type: $state.params.type });
-    }
+  function gotoCase(caseNumber) {
+      $state.go('declaration.show', { caseid: caseNumber, type: $state.params.type, index: $state.params.index });
+  }
 
-    vm.gotoCase = gotoCase;
+  vm.gotoCase = gotoCase;
+
+  function openCase(index) {
+    // we can't use $state.go here, as that would refresh the entire page
+
+    $state.params.index = index;
+    $location.search('index', index);
+    // $state.go('flowchart', {
+    //   index: index
+    // })
+  }
+
+  vm.openCase = openCase;
 
 
  function updateCollapse() {
@@ -86,49 +110,51 @@ function propertyFilter(array, query) {
   function activate() {
     $scope.isLoading = true;
 
-    FlowChartService.getEntries("total").then(function (response) {
+    if (!$rootScope.total) {
+      return FlowChartService.getEntries("total").then(function (response) {
+        $rootScope.total = {};
+        $rootScope.total.ongoing = response.ongoing;
+        $rootScope.total.arrestanter = response.arrestanter;
+        $rootScope.total.observation = response.observation;
+        $rootScope.total.user = response.user;
 
-    vm.total = {};
-                             vm.total.ongoing = response.ongoing;
-                             vm.total.arrestanter = response.arrestanter;
-                             vm.total.observation = response.observation;
-                             vm.total.user = response.user;
+        vm.showUser = ($rootScope.total.user != " -bruger ikke fundet-");
 
-                             vm.showUser = (vm.total.user != " -bruger ikke fundet-");
-
-                             vm.total.ventendegr = response.ventendegr;
-                             vm.total.waitinglist = response.waitinglist;
-                       });
-
-
-
-
-
-
+        $rootScope.total.ventendegr = response.ventendegr;
+        $rootScope.total.waitinglist = response.waitinglist;
+      });
+    } else {
+      return Promise.resolve(); // we already have data, just return a promise we can chain off of when invoking activate().
+    }
   }
 
   function loaddata(value, sort, desc) {
-    $state.go('flowchart', {
-      type: value
-    }).then(function(state) {
+    // only load data if we switched to a new type
+    if (!$rootScope.currentType || $rootScope.currentType !== value) {
+      var index = $rootScope.currentType && $rootScope.currentType !== value ? -1 : $state.params.index;
+      $rootScope.currentType = value;
+      $rootScope.ongoing = []
+      return $state.go('flowchart', {
+        type: value,
+        index: index
+      }).then(function() {
+        vm.showing = value;
+        vm.currentCard = value;
+
+        return FlowChartService.getEntries(value, sort, desc);
+      }).then(function (response) {
+        $rootScope.ongoing = response.entries;
+      });
+    } else {
       vm.showing = value;
       vm.currentCard = value;
-
-      return FlowChartService.getEntries(value, sort, desc);
-    }).then(function (response) {
-      vm.ongoing = response.entries;
-    });
+      return Promise.resolve(); // we already have the data, just return a dummy Promise
+    }
   }
-
-
 
   vm.loaddata = loaddata;
 
-
-
-
-
-  function save(nodeuuid, doctor, socialworker, psychologist, status) {
+  function save(nodeuuid, doctor, socialworker, psychologist, status, index) {
 
     DeclarationService.update($scope.flow)
     			.then(function (response) {
@@ -138,7 +164,7 @@ function propertyFilter(array, query) {
     				vm.startedit = false;
     				vm.saveShow = false;
 
-                    vm.updateCard(response);
+                    vm.updateCard(response, index, true);
 
 
                     $timeout(function () {
@@ -165,99 +191,100 @@ function propertyFilter(array, query) {
 
 
 
-    function updateCard(i) {
-         DeclarationService.get(i.caseNumber).then(function (response) {
-
-                var val = angular.element(document.getElementById("statusDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.status);
-                var val = angular.element(document.getElementById("samtykkeDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.samtykkeopl);
-
-
-                var val = angular.element(document.getElementById("arrestDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.arrest);
-                var val = angular.element(document.getElementById("tolksprogDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.tolksprog);
+  function updateCard(i, index, force) {
+    // only load data if we switched to a new index or forced a reload
+    if (!$rootScope.currentIndex || $rootScope.currentIndex !== index || force) {
+      $rootScope.currentIndex = index;
+      DeclarationService.get(i.caseNumber).then(function (response) {
+        var val = angular.element(document.getElementById("statusDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.status);
+        var val = angular.element(document.getElementById("samtykkeDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.samtykkeopl);
 
 
-                var val = angular.element(document.getElementById("socialworkerDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.socialworker);
-                var val = angular.element(document.getElementById("fritidvedDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.fritidved);
+        var val = angular.element(document.getElementById("arrestDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.arrest);
+        var val = angular.element(document.getElementById("tolksprogDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.tolksprog);
 
 
-                var val = angular.element(document.getElementById("doctorDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.doctor);
-                var val = angular.element(document.getElementById("kommentarDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.kommentar);
-                var val = angular.element(document.getElementById("oplysningerEksterntDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.oplysningerEksternt);
-
-                var val = angular.element(document.getElementById("psychologistDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.psychologist);
-                var val = angular.element(document.getElementById("kvalitetskontrolDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.kvalitetskontrol);
+        var val = angular.element(document.getElementById("socialworkerDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.socialworker);
+        var val = angular.element(document.getElementById("fritidvedDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.fritidved);
 
 
-                var val = angular.element(document.getElementById("psykologfokusDisplay_"+ response["node-uuid"]));
-                val[0].innerText = formatEmpty(response.psykologfokus);
+        var val = angular.element(document.getElementById("doctorDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.doctor);
+        var val = angular.element(document.getElementById("kommentarDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.kommentar);
+        var val = angular.element(document.getElementById("oplysningerEksterntDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.oplysningerEksternt);
 
-                });
+        var val = angular.element(document.getElementById("psychologistDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.psychologist);
+        var val = angular.element(document.getElementById("kvalitetskontrolDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.kvalitetskontrol);
+
+        var val = angular.element(document.getElementById("psykologfokusDisplay_"+ response["node-uuid"]));
+        val[0].innerText = formatEmpty(response.psykologfokus);
+      });
     }
+  }
 
-    vm.updateCard = updateCard;
-
-
-    function editCase(i) {
-
-    var currentUser = authService.getUserInfo().user.userName
-
-          return (DeclarationService.get(i.caseNumber).then(function (response) {
-
-            // init locked4edit
-
-            if (response.locked4edit == null) {
-                response.locked4edit = false;
-            }
+  vm.updateCard = updateCard;
 
 
-            if (response.locked4edit) {
-                if (response.locked4editBy != currentUser) {
-                    alert("sagen er låst for redigering af " + response.locked4editBy);
-                    vm.startedit = false;
-                    vm.saveShow = false;
-                    vm.editing=false
-                    return false;
-                }
-            }
+  function editCase(i) {
 
-            $scope.flow["samtykkeopl"] = response.samtykkeopl;
-            $scope.flow["kommentar"] = response.kommentar;
-            $scope.flow["oplysningerEksternt"] = response.oplysningerEksternt;
-            $scope.flow["arrest"] = response.arrest;
-            $scope.flow["tolksprog"] = response.tolksprog;
-            $scope.flow["psykologfokus"] = response.psykologfokus;
-            $scope.flow["fritidved"] = response.fritidved;
-            $scope.flow["kvalitetskontrol"] = response.kvalitetskontrol;
-            $scope.flow["node-uuid"] = response["node-uuid"];
-            $scope.flow["psychologist"] = response.psychologist;
-            $scope.flow["socialworker"] = response.socialworker;
-            $scope.flow["doctor"] = response.doctor;
-            $scope.flow["status"] = response.status;
+  var currentUser = authService.getUserInfo().user.userName
+
+        return (DeclarationService.get(i.caseNumber).then(function (response) {
+
+          // init locked4edit
+
+          if (response.locked4edit == null) {
+              response.locked4edit = false;
+          }
 
 
-            vm.editperid = response["node-uuid"]
-            vm.startedit = true;
-            vm.saveShow = true;
+          if (response.locked4edit) {
+              if (response.locked4editBy != currentUser) {
+                  alert("sagen er låst for redigering af " + response.locked4editBy);
+                  vm.startedit = false;
+                  vm.saveShow = false;
+                  vm.editing=false
+                  return false;
+              }
+          }
 
-            lockedForEdit(true);
+          $scope.flow["samtykkeopl"] = response.samtykkeopl;
+          $scope.flow["kommentar"] = response.kommentar;
+          $scope.flow["oplysningerEksternt"] = response.oplysningerEksternt;
+          $scope.flow["arrest"] = response.arrest;
+          $scope.flow["tolksprog"] = response.tolksprog;
+          $scope.flow["psykologfokus"] = response.psykologfokus;
+          $scope.flow["fritidved"] = response.fritidved;
+          $scope.flow["kvalitetskontrol"] = response.kvalitetskontrol;
+          $scope.flow["node-uuid"] = response["node-uuid"];
+          $scope.flow["psychologist"] = response.psychologist;
+          $scope.flow["socialworker"] = response.socialworker;
+          $scope.flow["doctor"] = response.doctor;
+          $scope.flow["status"] = response.status;
 
-            return true;
 
-        }));
+          vm.editperid = response["node-uuid"]
+          vm.startedit = true;
+          vm.saveShow = true;
+
+          lockedForEdit(true);
+
+          return true;
+
+      }));
 
 
-    }
+  }
 
 
   function checkif() {

--- a/app/src/flowchart/flowchart.controller.js
+++ b/app/src/flowchart/flowchart.controller.js
@@ -60,6 +60,11 @@ function FlowChartController($scope, $rootScope, $translate, HeaderService, Flow
 
   // on page load, get the data
   activate().then(function() {
+
+    if ($state.params.type == undefined) {
+     $state.params.type = 'ongoing';
+    }
+
     return loaddata($state.params.type, '@rm:creationDate', 'true');
   }).then(function() {
     if ($rootScope.ongoing && $rootScope.ongoing.length && $state.params.index > -1) {

--- a/app/src/flowchart/flowchart.html
+++ b/app/src/flowchart/flowchart.html
@@ -182,7 +182,7 @@
     </div>
 
     <div class="flowchart-content">
-        <div ng-repeat="i in vm.ongoing" ng-if="!vm.minesager">
+        <div ng-repeat="i in ongoing" ng-if="!vm.minesager">
             <ng-include src="'app/src/flowchart/data-row.html'"></ng-include>
         </div>
     </div>

--- a/app/src/flowchart/flowchart.module.js
+++ b/app/src/flowchart/flowchart.module.js
@@ -8,7 +8,7 @@ function config($stateProvider) {
   $stateProvider
     .state('flowchart', {
       parent: 'site',
-      url: '/flowchart',
+      url: '/flowchart?:type',
       params: {
         path: "/flowchart",
         breadcrumbPath: []
@@ -26,4 +26,3 @@ function config($stateProvider) {
 
     });
 }
-

--- a/app/src/flowchart/flowchart.module.js
+++ b/app/src/flowchart/flowchart.module.js
@@ -8,7 +8,7 @@ function config($stateProvider) {
   $stateProvider
     .state('flowchart', {
       parent: 'site',
-      url: '/flowchart?:type',
+      url: '/flowchart?:type&:index',
       params: {
         path: "/flowchart",
         breadcrumbPath: []

--- a/app/src/flowchart/flowchart_alle.html
+++ b/app/src/flowchart/flowchart_alle.html
@@ -13,7 +13,7 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
 
 <div class="md-title">Arrestanter <a ng-click="vm.scroll('Ongoing')">næste</a> </div>
 
-<div  ng-show="vm.alle" ng-repeat="i in vm.ongoing.arrestanter" >
+<div  ng-show="vm.alle" ng-repeat="i in ongoing.arrestanter" >
     <md-card class="dropdown-card" id="{{ i.node_uuid }}" ng-hide="!(vm.editperid == i.node_uuid) && vm.startedit">
 
 
@@ -303,9 +303,9 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
             </md-button>
             <!--<md-button ng-disabled="save" ng-click="collapsed=vm.editCase(i);edit=collapsed;save=collapsed;">ret  </md-button>-->
             <md-button ng-disabled="vm.saveShow" ng-click="collapsed=vm.editCase(i);save=collapsed; ">ret  </md-button>
-            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status)" ng-show="vm.saveShow">gem</md-button>
+            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status, $index)" ng-show="vm.saveShow">gem</md-button>
             <md-button ng-click="save=false;edit=false;vm.cancel(i.node_uuid)" ng-show="vm.saveShow">annuller</md-button>
-            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.updateCard(i)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
+            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.openCase($index)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
             <md-button ng-show="collapsed" ng-click="collapsed=!collapsed"> <md-icon>keyboard_arrow_up</md-icon> </md-button>
 
 
@@ -322,7 +322,7 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
 <a class="anchor" id="Ongoing"></a>
 <div class="md-title"> <a ng-click="vm.scroll('Arrestanter')">forrige</a> Igangværende <a ng-click="vm.scroll('Waitinglist')">næste</a> </div>
 
-<div  ng-show="vm.alle" ng-repeat="i in vm.ongoing.ongoing" >
+<div  ng-show="vm.alle" ng-repeat="i in ongoing.ongoing" >
     <md-card class="dropdown-card" id="{{ i.node_uuid }}" ng-hide="!(vm.editperid == i.node_uuid) && vm.startedit">
 
 
@@ -612,9 +612,9 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
             </md-button>
             <!--<md-button ng-disabled="save" ng-click="collapsed=vm.editCase(i);edit=collapsed;save=collapsed;">ret  </md-button>-->
             <md-button ng-disabled="vm.saveShow" ng-click="collapsed=vm.editCase(i);save=collapsed; ">ret  </md-button>
-            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status)" ng-show="vm.saveShow">gem</md-button>
+            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status, $index)" ng-show="vm.saveShow">gem</md-button>
             <md-button ng-click="save=false;edit=false;vm.cancel(i.node_uuid)" ng-show="vm.saveShow">annuller</md-button>
-            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.updateCard(i)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
+            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.openCase($index)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
             <md-button ng-show="collapsed" ng-click="collapsed=!collapsed"> <md-icon>keyboard_arrow_up</md-icon> </md-button>
 
 
@@ -632,7 +632,7 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
 <a class="anchor" id="Waitinglist"></a>
 <div class="md-title"> <a ng-click="vm.scroll('Ongoing')">forrige</a> Venteliste <a ng-click="vm.scroll('Indlagt')">næste</a> </div>
 
-<div  ng-show="vm.alle" ng-repeat="i in vm.ongoing.waitinglist" >
+<div  ng-show="vm.alle" ng-repeat="i in ongoing.waitinglist" >
     <md-card class="dropdown-card" id="{{ i.node_uuid }}" ng-hide="!(vm.editperid == i.node_uuid) && vm.startedit">
 
 
@@ -922,9 +922,9 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
             </md-button>
             <!--<md-button ng-disabled="save" ng-click="collapsed=vm.editCase(i);edit=collapsed;save=collapsed;">ret  </md-button>-->
             <md-button ng-disabled="vm.saveShow" ng-click="collapsed=vm.editCase(i);save=collapsed; ">ret  </md-button>
-            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status)" ng-show="vm.saveShow">gem</md-button>
+            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status, $index)" ng-show="vm.saveShow">gem</md-button>
             <md-button ng-click="save=false;edit=false;vm.cancel(i.node_uuid)" ng-show="vm.saveShow">annuller</md-button>
-            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.updateCard(i)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
+            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.openCase($index)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
             <md-button ng-show="collapsed" ng-click="collapsed=!collapsed"> <md-icon>keyboard_arrow_up</md-icon> </md-button>
 
 
@@ -941,7 +941,7 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
 <a class="anchor" id="Indlagte"></a>
 <div class="md-title"> <a ng-click="vm.scroll('Waitinglist')">forrige</a> Indlagte <a ng-click="vm.scroll('Ongoing')">næste</a> </div>
 
-<div  ng-show="vm.alle" ng-repeat="i in vm.ongoing.observation" >
+<div  ng-show="vm.alle" ng-repeat="i in ongoing.observation" >
     <md-card class="dropdown-card" id="{{ i.node_uuid }}" ng-hide="!(vm.editperid == i.node_uuid) && vm.startedit">
 
 
@@ -1231,9 +1231,9 @@ a.anchor{display: block; position: relative; top: -250px; visibility: hidden;}
             </md-button>
             <!--<md-button ng-disabled="save" ng-click="collapsed=vm.editCase(i);edit=collapsed;save=collapsed;">ret  </md-button>-->
             <md-button ng-disabled="vm.saveShow" ng-click="collapsed=vm.editCase(i);save=collapsed; ">ret  </md-button>
-            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status)" ng-show="vm.saveShow">gem</md-button>
+            <md-button ng-click="save=false;edit=false;vm.save(i.node_uuid, i.doctor, i.socialworker, i.psychologist, i.status, $index)" ng-show="vm.saveShow">gem</md-button>
             <md-button ng-click="save=false;edit=false;vm.cancel(i.node_uuid)" ng-show="vm.saveShow">annuller</md-button>
-            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.updateCard(i)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
+            <md-button ng-show="!collapsed" ng-click="collapsed=!collapsed;vm.openCase($index)" > <md-icon>keyboard_arrow_down</md-icon> </md-button>
             <md-button ng-show="collapsed" ng-click="collapsed=!collapsed"> <md-icon>keyboard_arrow_up</md-icon> </md-button>
 
 

--- a/app/src/flowchart/flowchart_minesager.html
+++ b/app/src/flowchart/flowchart_minesager.html
@@ -3,7 +3,7 @@
 <div class="md-title"><h3>Arrestanter:</h3></div>
 
 <div class="flowchart-content">
-    <div ng-repeat="i in vm.ongoing.arrestanter">
+    <div ng-repeat="i in ongoing.arrestanter">
         <ng-include src="'app/src/flowchart/data-row.html'"></ng-include>
     </div>
 </div>
@@ -11,7 +11,7 @@
 <div class="md-title"><h3>Andre:</h3></div>
 
 <div class="flowchart-content">
-    <div ng-repeat="i in vm.ongoing.andre">
+    <div ng-repeat="i in ongoing.andre">
         <ng-include src="'app/src/flowchart/data-row.html'"></ng-include>
     </div>
 </div>

--- a/app/src/flowchart/flowchart_navigation.html
+++ b/app/src/flowchart/flowchart_navigation.html
@@ -1,25 +1,25 @@
 <div class="flowchart-navigation">
     <md-button class="md-raised {{vm.currentCard == 'arrestanter' ?'md-primary':'default'}}" ng-click="vm.minesager=false;vm.loaddata('arrestanter', '@rm:creationDate', 'true')">
-        {{'COMMON.ARRESTANTER' | translate }} <span class="flowchart-count">({{ vm.total.arrestanter }})</span>
+        {{'COMMON.ARRESTANTER' | translate }} <span class="flowchart-count">({{ total.arrestanter }})</span>
     </md-button>
 
     <md-button class="md-raised {{vm.currentCard == 'ongoing' ?'md-primary':'default'}}" ng-click="vm.minesager=false;vm.loaddata('ongoing', '@rm:creationDate', 'true')">
-        {{'COMMON.IGANGVÆRENDE' | translate }} <span class="flowchart-count">({{ vm.total.ongoing }})</span>
+        {{'COMMON.IGANGVÆRENDE' | translate }} <span class="flowchart-count">({{ total.ongoing }})</span>
     </md-button>
 
     <md-button class="md-raised {{vm.currentCard == 'waitinglist' ?'md-primary':'default'}}" ng-click="vm.minesager=false;vm.loaddata('waitinglist', '@rm:creationDate', 'true')">
-        {{'COMMON.VENTELISTE' | translate }} <span class="flowchart-count">({{ vm.total.waitinglist }})</span>
+        {{'COMMON.VENTELISTE' | translate }} <span class="flowchart-count">({{ total.waitinglist }})</span>
     </md-button>
 
     <md-button class="md-raised {{vm.currentCard == 'observation' ?'md-primary':'default'}}" ng-click="vm.minesager=false;vm.loaddata('observation', '@rm:creationDate', 'true')">
-        {{'COMMON.INDLAGTE' | translate }} <span class="flowchart-count">({{ vm.total.observation }})</span>
+        {{'COMMON.INDLAGTE' | translate }} <span class="flowchart-count">({{ total.observation }})</span>
     </md-button>
 
     <md-button class="md-raised {{vm.currentCard == 'ventendegr' ?'md-primary':'default'}}" ng-click="vm.minesager=false;vm.loaddata('ventendegr', '@rm:creationDate', 'true')">
-        {{'COMMON.VENTEDEGR' | translate }} <span class="flowchart-count">({{ vm.total.ventendegr }})</span>
+        {{'COMMON.VENTEDEGR' | translate }} <span class="flowchart-count">({{ total.ventendegr }})</span>
     </md-button>
 
     <md-button class="md-raised {{vm.currentCard == 'user' ?'md-primary':'default'}}" ng-show="vm.showUser" ng-click="vm.minesager=true;vm.loaddata('user', '@rm:creationDate', 'true')">
-        {{'COMMON.MINESAGER' | translate }} <span class="flowchart-count">({{ vm.total.user }})</span>
+        {{'COMMON.MINESAGER' | translate }} <span class="flowchart-count">({{ total.user }})</span>
     </md-button>
 </div>

--- a/app/src/header/header.controller.js
+++ b/app/src/header/header.controller.js
@@ -40,11 +40,18 @@ function HeaderController($scope, $transitions, HeaderService, authService, $sta
       }
   	});
 
+    $transitions.onStart({ from: 'declaration.show.**' }, function (transition) {
+      $timeout(function () {
+        vm.previous = null;
+      }, 100); // wait for the $state.go() to finish in vm.goback()
+    });
+
     function goback() {
         HeaderService.setBacktosearchStatus(false);
     $timeout(function() {
-       $state.go(vm.previous.name, vm.previous.params);
-       vm.previous = null
+       $state.go(vm.previous.name, vm.previous.params).then(function() {
+         vm.previous = null;
+       });
     });
 
 

--- a/app/src/header/header.controller.js
+++ b/app/src/header/header.controller.js
@@ -4,7 +4,7 @@ angular
     .module('openDeskApp')
     .controller('HeaderController', HeaderController);
 
-function HeaderController($scope, $transitions, HeaderService, authService, $state, $timeout) {
+function HeaderController($scope, $transitions, HeaderService, authService, $state, $stateParams, $timeout) {
 
     var vm = this;
 
@@ -28,11 +28,11 @@ function HeaderController($scope, $transitions, HeaderService, authService, $sta
     });
 
   	// when transitioning to the view, store which view we came from
-  	$transitions.onStart({ to: 'declaration.show.patientdata' }, function (transition) {
-      var previousView = transition.$from();
-      if (previousView.name === 'declaration.advancedSearch' || previousView.name === 'flowchart') {
+  	$transitions.onStart({ to: 'declaration.show.**' }, function (transition) {
+      var fromName = transition.from().name;
+      if (fromName === 'declaration.advancedSearch' || fromName === 'flowchart') {
         vm.previous = {
-          name: transition.from().name,
+          name: fromName,
           params: transition.params()
         }
       } else {

--- a/app/src/header/header.view.html
+++ b/app/src/header/header.view.html
@@ -36,7 +36,7 @@
                 <h2>{{vm.title}}</h2>
             </a>
 
-            <md-button ng-if="vm.backtosearch"  title="tilbage til søgning" ui-sref="administration" ng-click="vm.gobacktosearch()">
+            <md-button ng-if="vm.previous"  title="tilbage til søgning" ui-sref="administration" ng-click="vm.goback()">
                         <span>tilbage til søgning</span>
             </md-button>
 

--- a/app/src/header/header.view.html
+++ b/app/src/header/header.view.html
@@ -35,9 +35,8 @@
             <a ui-sref="declaration.show({caseid: vm.caseId})" style="color:white">
                 <h2>{{vm.title}}</h2>
             </a>
-
-            <md-button ng-if="vm.previous"  title="tilbage til søgning" ui-sref="administration" ng-click="vm.goback()">
-                        <span>tilbage til søgning</span>
+            <md-button ng-if="vm.previous"  title="tilbage" ui-sref="administration" ng-click="vm.goback()">
+                        <span>tilbage</span>
             </md-button>
 
 


### PR DESCRIPTION
This MR enables the back button for both flowchart and advanced search actions.

In order for the flowchart to function properly, I made it so that the URL takes `type` and `index` parameters. That should open the relevant section (e.g. "Arrestanter") and expand the relevant item in the list when you navigate to the page.

For this to work, I had to save the fetched flowchart data in the `$rootScope` so that it is not reset between navigation actions (where opening a new section (e.g. "Ventende") *and* expanding a new item count as navigation actions).

One issue that I didn't manage to solve properly, but rather had to work around, is the fact that it takes some time for the UI to render when new data is fetched via `FlowChartService.getEntries()`. Specifically, setting the value of `$rootScope.ongoing` requires a rather large UI re-render which takes a while. I couldn't find a way to properly listen for view render cycles, so I resorted to using `setInterval` and, at each interval, check if the UI was updated (line 65-77).

Other than that, I used `$transition.onStart` in the header component to detect navigation actions to the declaration view. IMHO that's a lot easier and simpler than storing the previous query in the `HeaderService`, where you have to remember to update and reset it.